### PR TITLE
Make the phpcs config file compatible with SticklerCI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,8 +42,8 @@
     },
     "scripts": {
         "test": "phpunit",
-        "check-style": "phpcs --standard=./phpcs.xml",
-        "fix-style": "phpcbf --standard=./phpcs.xml"
+        "check-style": "phpcs --standard=./phpcs.xml -p",
+        "fix-style": "phpcbf --standard=./phpcs.xml -p"
     },
     "extra": {
         "branch-alias": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <ruleset name="Custom Standard">
-    <arg value="p"/>
     <config name="ignore_errors_on_exit" value="true"/>
     <config name="ignore_warnings_on_exit" value="true"/>
 

--- a/src/Feature.php
+++ b/src/Feature.php
@@ -23,12 +23,12 @@ abstract class Feature
 
     abstract public function toggles(): array;
 
-    public static function registerResolver($resolver)
+    public static function registerResolver($resolver): void
     {
         self::$resolver = $resolver;
     }
 
-    public function resolver()
+    public function resolver(): Resolver
     {
         if (! self::$resolver) {
             self::registerResolver(new DefaultResolver);


### PR DESCRIPTION
## Description

We had to remove the `p` (show progress) argument from the `phpcs.xml` config file because having the progress turned on in the config caused Stickler to not work.

I just moved the `p` argument to the `check-style` and `fix-style` scripts in `composer.json`